### PR TITLE
Add mock as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 # Add that to the dev reqs file for now, since it's not needed when running
 dependencies = ['click', 'genologics', 'requests-cache', 'pyyaml', 'nose', 'PyPDF2',
-                'lxml', 'coverage', 'pep8radius']
+                'lxml', 'coverage', 'pep8radius', 'mock']
 
 setup(
     name='clarity-ext',


### PR DESCRIPTION
I noticed that mock was missing from the list of dependencies. Here it is. :smile: 